### PR TITLE
Use profile links from 'social' object

### DIFF
--- a/_includes/social.html
+++ b/_includes/social.html
@@ -1,106 +1,106 @@
 <ul>
-    {% if site.facebook %}
-    <li><a class="fa fa-2x fa-facebook" href="https://facebook.com/{{ site.facebook }}"><span class="description">Facebook</span></a></li>
+    {% if site.social.facebook %}
+    <li><a class="fa fa-2x fa-facebook" href="https://facebook.com/{{ site.social.facebook }}"><span class="description">Facebook</span></a></li>
     {% endif %}
 
-    {% if site.twitter %}
-    <li><a class="fa fa-2x fa-twitter" href="https://twitter.com/{{ site.twitter }}"><span class="description">Twitter</span></a></li>
+    {% if site.social.twitter %}
+    <li><a class="fa fa-2x fa-twitter" href="https://twitter.com/{{ site.social.twitter }}"><span class="description">Twitter</span></a></li>
     {% endif %}
 
-    {% if site.linkedin %}
-    <li><a class="fa fa-2x fa-linkedin" href="https://linkedin.com/in/{{ site.linkedin }}"><span class="description">LinkedIn</span></a></li>
+    {% if site.social.linkedin %}
+    <li><a class="fa fa-2x fa-linkedin" href="https://linkedin.com/in/{{ site.social.linkedin }}"><span class="description">LinkedIn</span></a></li>
     {% endif %}
 
-    {% if site.google_plus %}
-    <li><a class="fa fa-2x fa-google-plus" href="https://plus.google.com/+{{ site.google_plus }}"><span class="description">Google +</span></a></li>
+    {% if site.social.google_plus %}
+    <li><a class="fa fa-2x fa-google-plus" href="https://plus.google.com/+{{ site.social.google_plus }}"><span class="description">Google +</span></a></li>
     {% endif %}
 
-    {% if site.vk %}
-    <li><a class="fa fa-2x fa-vk" href="https://vk.com/{{ site.vk }}"><span class="description">ВКонтакте</span></a></li>
+    {% if site.social.vk %}
+    <li><a class="fa fa-2x fa-vk" href="https://vk.com/{{ site.social.vk }}"><span class="description">ВКонтакте</span></a></li>
     {% endif %}
 
-    {% if site.weibo %}
-    <li><a class="fa fa-2x fa-weibo" href="https://weibo.com/{{ site.weibo }}"><span class="description">微博</span></a></li>
+    {% if site.social.weibo %}
+    <li><a class="fa fa-2x fa-weibo" href="https://weibo.com/{{ site.social.weibo }}"><span class="description">微博</span></a></li>
     {% endif %}
 
-    {% if site.instagram %}
-    <li><a class="fa fa-2x fa-instagram" href="https://instagram.com/{{ site.instagram }}"><span class="description">Instagram</span></a></li>
+    {% if site.social.instagram %}
+    <li><a class="fa fa-2x fa-instagram" href="https://instagram.com/{{ site.social.instagram }}"><span class="description">Instagram</span></a></li>
     {% endif %}
 
-    {% if site.flickr %}
-    <li><a class="fa fa-2x fa-flickr" href="https://flickr.com/photos/{{ site.flickr }}"><span class="description">Flickr</span></a></li>
+    {% if site.social.flickr %}
+    <li><a class="fa fa-2x fa-flickr" href="https://flickr.com/photos/{{ site.social.flickr }}"><span class="description">Flickr</span></a></li>
     {% endif %}
 
-    {% if site.pinterest %}
-    <li><a class="fa fa-2x fa-pinterest" href="https://pinterest.com/{{ site.pinterest }}"><span class="description">Pinterest</span></a></li>
+    {% if site.social.pinterest %}
+    <li><a class="fa fa-2x fa-pinterest" href="https://pinterest.com/{{ site.social.pinterest }}"><span class="description">Pinterest</span></a></li>
     {% endif %}
 
-    {% if site.github %}
-    <li><a class="fa fa-2x fa-github" href="https://github.com/{{ site.github }}"><span class="description">GitHub</span></a></li>
+    {% if site.social.github %}
+    <li><a class="fa fa-2x fa-github" href="https://github.com/{{ site.social.github }}"><span class="description">GitHub</span></a></li>
     {% endif %}
 
-    {% if site.codepen %}
-    <li><a class="fa fa-2x fa-codepen" href="https://codepen.io/{{ site.codepen }}"><span class="description">CodePen</span></a></li>
+    {% if site.social.codepen %}
+    <li><a class="fa fa-2x fa-codepen" href="https://codepen.io/{{ site.social.codepen }}"><span class="description">CodePen</span></a></li>
     {% endif %}
 
-    {% if site.stack-overflow %}
-    <li><a class="fa fa-2x fa-stack-overflow" href="https://stackoverflow.com/users/{{ site.stack-overflow }}"><span class="description">Stack Overflow</span></a></li>
+    {% if site.social.stack-overflow %}
+    <li><a class="fa fa-2x fa-stack-overflow" href="https://stackoverflow.com/users/{{ site.social.stack-overflow }}"><span class="description">Stack Overflow</span></a></li>
     {% endif %}
 
-    {% if site.reddit %}
-    <li><a class="fa fa-2x fa-reddit" href="https://reddit.com/user/{{ site.reddit }}"><span class="description">Reddit</span></a></li>
+    {% if site.social.reddit %}
+    <li><a class="fa fa-2x fa-reddit" href="https://reddit.com/user/{{ site.social.reddit }}"><span class="description">Reddit</span></a></li>
     {% endif %}
 
-    {% if site.steam %}
-    <li><a class="fa fa-2x fa-steam" href="http://steamcommunity.com/id/{{ site.steam }}"><span class="description">Steam</span></a></li>
+    {% if site.social.steam %}
+    <li><a class="fa fa-2x fa-steam" href="http://steamcommunity.com/id/{{ site.social.steam }}"><span class="description">Steam</span></a></li>
     {% endif %}
 
-    {% if site.youtube %}
-    <li><a class="fa fa-2x fa-youtube-play" href="https://youtube.com/channel/{{ site.youtube }}"><span class="description">YouTube</span></a></li>
+    {% if site.social.youtube %}
+    <li><a class="fa fa-2x fa-youtube-play" href="https://youtube.com/channel/{{ site.social.youtube }}"><span class="description">YouTube</span></a></li>
     {% endif %}
 
-    {% if site.vimeo %}
-    <li><a class="fa fa-2x fa-vimeo" href="https://vimeo.com/{{ site.vimeo }}"><span class="description">Vimeo</span></a></li>
+    {% if site.social.vimeo %}
+    <li><a class="fa fa-2x fa-vimeo" href="https://vimeo.com/{{ site.social.vimeo }}"><span class="description">Vimeo</span></a></li>
     {% endif %}
 
-    {% if site.soundcloud %}
-    <li><a class="fa fa-2x fa-soundcloud" href="https://soundcloud.com/{{ site.soundcloud }}"><span class="description">Soundcloud</span></a></li>
+    {% if site.social.soundcloud %}
+    <li><a class="fa fa-2x fa-soundcloud" href="https://soundcloud.com/{{ site.social.soundcloud }}"><span class="description">Soundcloud</span></a></li>
     {% endif %}
 
-    {% if site.lastfm %}
-    <li><a class="fa fa-2x fa-lastfm" href="http://www.last.fm/user/{{ site.lastfm }}"><span class="description">Last.fm</span></a></li>
+    {% if site.social.lastfm %}
+    <li><a class="fa fa-2x fa-lastfm" href="http://www.last.fm/user/{{ site.social.lastfm }}"><span class="description">Last.fm</span></a></li>
     {% endif %}
 
-    {% if site.medium %}
-    <li><a class="fa fa-2x fa-medium" href="https://medium.com/@{{ site.medium }}"><span class="description">Medium</span></a></li>
+    {% if site.social.medium %}
+    <li><a class="fa fa-2x fa-medium" href="https://medium.com/@{{ site.social.medium }}"><span class="description">Medium</span></a></li>
     {% endif %}
 
-    {% if site.tumblr %}
-    <li><a class="fa fa-2x fa-tumblr" href="https://{{ site.tumblr }}.tumblr.com/"><span class="description">Tumblr</span></a></li>
+    {% if site.social.tumblr %}
+    <li><a class="fa fa-2x fa-tumblr" href="https://{{ site.social.tumblr }}.tumblr.com/"><span class="description">Tumblr</span></a></li>
     {% endif %}
 
-    {% if site.blog_url %}
-    <li><a class="fa fa-2x fa-tags" href="{{ site.blog_url }}"><span class="description">Blog</span></a></li>
+    {% if site.social.blog_url %}
+    <li><a class="fa fa-2x fa-tags" href="{{ site.social.blog_url }}"><span class="description">Blog</span></a></li>
     {% endif %}
 
-    {% if site.keybase %}
-    <li><a class="fa fa-2x fa-key" href="https://keybase.io/{{ site.keybase }}"><span class="description">Keybase</span></a></li>
+    {% if site.social.keybase %}
+    <li><a class="fa fa-2x fa-key" href="https://keybase.io/{{ site.social.keybase }}"><span class="description">Keybase</span></a></li>
     {% endif %}
 
-    {% if site.email %}
-    <li><a class="fa fa-2x fa-envelope" href="mailto:{{ site.email }}"><span class="description">Email</span></a></li>
+    {% if site.social.email %}
+    <li><a class="fa fa-2x fa-envelope" href="mailto:{{ site.social.email }}"><span class="description">Email</span></a></li>
     {% endif %}
 
-    {% if site.messenger %}
-    <li><a class="fa fa-2x fa-facebook-messenger" href="https://m.me/{{ site.messenger }}"><span class="description">Messenger</span></a></li>
+    {% if site.social.messenger %}
+    <li><a class="fa fa-2x fa-facebook-messenger" href="https://m.me/{{ site.social.messenger }}"><span class="description">Messenger</span></a></li>
     {% endif %}
 
-    {% if site.telegram %}
-    <li><a class="fa fa-2x fa-paper-plane" href="https://telegram.me/{{ site.telegram }}"><span class="description">Telegram</span></a></li>
+    {% if site.social.telegram %}
+    <li><a class="fa fa-2x fa-paper-plane" href="https://telegram.me/{{ site.social.telegram }}"><span class="description">Telegram</span></a></li>
     {% endif %}
 
-    {% if site.snapchat %}
-    <li><a class="fa fa-2x fa-snapchat" href="https://snapchat.com/add/{{ site.snapchat }}"><span class="description">Snapchat</span></a></li>
+    {% if site.social.snapchat %}
+    <li><a class="fa fa-2x fa-snapchat" href="https://snapchat.com/add/{{ site.social.snapchat }}"><span class="description">Snapchat</span></a></li>
     {% endif %}
 
     {% include too_social.html %}

--- a/_includes/too_social.html
+++ b/_includes/too_social.html
@@ -2,8 +2,8 @@
 
 Is there a social network that is not included in the default theme? Then, copy-paste the following lines of code outside of this comment-block and fill-in the details with your preferred social network.
 
-    {% if site.social_network_name %}
+    {% if site.social.social_network_name %}
     <li><a class="fa fa-2x fa-social_network_icon" href="social_network_url"><span class="description">social_network_name</span></a></li>
     {% endif %}
-    
+
 -->


### PR DESCRIPTION
While setting up this theme, I figured out that if I'm not using github social, 'site.github' where already defined by github itself. https://help.github.com/articles/repository-metadata-on-github-pages/#available-repository-metadata

I moved all social links to a 'social' object.

This PR comes in two chunks, one per branch.