### PR TITLE
Update fontawesome stylesheet

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,4 +7,4 @@
 {% if site.favicon %}
 <link rel="shortcut icon" href="{{ site.favicon }}" />
 {% endif %}
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.1/css/all.css" crossorigin="anonymous">
+<script src="https://kit.fontawesome.com/f7bad4bd2f.js"></script>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -7,4 +7,4 @@
 {% if site.favicon %}
 <link rel="shortcut icon" href="{{ site.favicon }}" />
 {% endif %}
-<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.9.0/css/all.css" integrity="sha384-G0fIWCsCzJIMAVNQPfjH08cyYaUtMwjJwqiRKxxE/rx96Uroj1BtIQ6MLJuheaO9" crossorigin="anonymous">
+<link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.10.1/css/all.css" crossorigin="anonymous">


### PR DESCRIPTION
* Updates "fontawesome" stylesheet to version `v5.10.1`
* Removes `integrity` outdated checksum from stylesheet link - Is this still needed?

Where can I find the integrity checksum on https://fontawesome.com/ ?